### PR TITLE
fix: Creation of dynamic property PHP::$modules is deprecated

### DIFF
--- a/src/Classes/PHPVersions/PHP8_2/PHP.php
+++ b/src/Classes/PHPVersions/PHP8_2/PHP.php
@@ -8,6 +8,8 @@ use Gorkau\DockerPhpGenerator\Classes\PHPVersions\PHP8_2\Gd;
 class PHP implements PHPVersionInterface
 {
     const CONCATENATOR = " && ";
+    private $modules = [];
+
     public function __construct(array $modules) {
         foreach($modules as $module) {
             $moduleClass = __NAMESPACE__ . "\\{$module}";


### PR DESCRIPTION
**OS:** macOS Sonoma 14.14
**PHP version:** PHP 8.2.16

**_Warning message description_**

_Deprecated: Creation of dynamic property Gorkau\DockerPhpGenerator\Classes\PHPVersions\PHP8_2\PHP::$modules is deprecated in .../src/Classes/PHPVersions/PHP8_2/PHP.php on line 14_

In PHP 7.4 and later versions, the creation of dynamic properties is discouraged. I think a possible fix could be to declare the _$modules_ property and initialize it as an empty array. You can now add elements to this array in your constructor as you are currently doing, and skip the warning showed above.

It's just an idea 😅 Maybe you think a better solution!.

Regards.